### PR TITLE
Add .phpt tests for the printer

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Github Actions printer for PHPUnit Test Suite">
+            <directory suffix=".phpt">./test/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -40,8 +40,12 @@ class Printer extends ResultPrinter
     {
         $e = $defect->thrownException();
 
-        $firstError = explode(PHP_EOL, (string)$e)[2];
-        list($path, $line) = explode(":", $firstError);
+        $errorLines = array_filter(
+            explode(PHP_EOL, (string)$e), 
+            function($l){ return $l; }
+        );
+
+        list($path, $line) = explode(":", end($errorLines));
 
         if (!$path) {
             list($path, $line) = $this->getReflectionFromTest($defect->getTestName());

--- a/test/_files/PrinterStatesTest.php
+++ b/test/_files/PrinterStatesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+class PrinterStatesTest extends PHPUnit\Framework\TestCase
+{
+    public function testSuccess()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testFailure()
+    {
+        $this->assertTrue(false);
+    }
+
+    public function testError()
+    {
+        strpos();
+    }
+
+    public function testMissing()
+    {
+        $this->isMissing();
+    }
+
+    public function testSkipped()
+    {
+        $this->markTestSkipped('Skipped');
+    }
+
+    public function testWarning()
+    {
+        throw new PHPUnit\Framework\Warning("This is a test warning");
+    }
+
+    public function testRisky()
+    {
+        throw new PHPUnit\Framework\RiskyTestError("This is a risky test");
+    }
+
+    public function testNoAssertions()
+    {
+    }
+
+    public function testIncomplete()
+    {
+        $this->markTestIncomplete('Incomplete');
+    }
+}
+

--- a/test/_files/phpunit.xml
+++ b/test/_files/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         printerFile="../../src/Printer.php"
+         printerClass="mheap\GithubActionsReporter\Printer"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="../../vendor/autoload.php"
+>
+
+</phpunit>

--- a/test/states-test.phpt
+++ b/test/states-test.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit -c tests/_files/phpunit.xml tests/_files/PrinterStatesTest.php
+--FILE--
+<?php
+$_SERVER['TERM']    = 'xterm';
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = dirname(__FILE__).'/_files/phpunit.xml';
+$_SERVER['argv'][3] = '--colors=always';
+$_SERVER['argv'][4] = dirname(__FILE__).'/_files/PrinterStatesTest.php';
+
+require_once(dirname(dirname(__FILE__))).'/vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit 8.5.2 by Sebastian Bergmann and contributors.
+
+::error file=test/_files/PrinterStatesTest.php,line=17::strpos() expects at least 2 parameters, 0 given
+::error file=test/_files/PrinterStatesTest.php,line=22::Call to undefined method PrinterStatesTest::isMissing()
+::warning file=test/_files/PrinterStatesTest.php,line=32::This is a test warning
+::error file=test/_files/PrinterStatesTest.php,line=12::Failed asserting that false is true.
+::warning file=test/_files/PrinterStatesTest.php,line=37::This is a risky test
+::warning file=test/_files/PrinterStatesTest.php,line=40::This test did not perform any assertions


### PR DESCRIPTION
This PR adds tests for various test states using the `.phpt` test harness.

Fixes #3 