### PR TITLE
Directory separator and compatible issue

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -22,7 +22,7 @@ class Printer extends ResultPrinter
     {
     }
 
-    protected function printDefects(array $defects, string $type): void
+    protected function printDefects(array $defects, $type): void
     {
         $this->currentType = $type;
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -73,7 +73,7 @@ class Printer extends ResultPrinter
 
     protected function relativePath(string $path)
     {
-        return str_replace(getcwd() . '/', '', $path);
+        return str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $path);
     }
 
     protected function getReflectionFromTest(string $name)

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -14,7 +14,7 @@ class Printer extends ResultPrinter
     {
     }
 
-    protected function writeProgress(string $progress): void
+    protected function writeProgress($progress): void
     {
     }
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -31,7 +31,7 @@ class Printer extends ResultPrinter
         }
     }
 
-    protected function printDefectHeader(TestFailure $defect, int $count): void
+    protected function printDefectHeader(TestFailure $defect, $count): void
     {
     }
 


### PR DESCRIPTION
use the built-in constant for loading directory separator based on the operating system, instead of hardcoded directory separator `/`