### PR TITLE
Always use reflection to check class filename

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -51,10 +51,13 @@ class Printer extends ResultPrinter
         $path = substr($error, 0, $lineIndex);
         $line = substr($error, $lineIndex + 1);
 
-        if (!$path) {
-            list($path, $line) = $this->getReflectionFromTest(
-                $defect->getTestName()
-            );
+        list($reflectedPath, $reflectedLine) = $this->getReflectionFromTest(
+            $defect->getTestName()
+        );
+
+        if($path !== $reflectedPath) {
+        	$path = $reflectedPath;
+        	$line = $reflectedLine;
         }
 
         $message = explode("\n", $e->getMessage())[0];


### PR DESCRIPTION
I am using [WP_Mock](https://github.com/10up/wp_mock) and all failures were returning the path as `vendor/10up/wp_mock/php/WP_Mock/Tools/TestCase.php:307` which is the file for the class that my test cases extend ([example](https://github.com/BrianHenryIE/BH-WP-Autologin-URLs/blob/master/tests/wp-mock/includes/class-bh-wp-autologin-urls-test.php)).

I've changed the code to use the path from `getReflectionFromTest()` as the definitive path, but to only overwrite the line number if the initial path was incorrect.