### PR TITLE
Enable multiline messages in annotations

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -57,7 +57,8 @@ class Printer extends ResultPrinter
             );
         }
 
-        $message = explode("\n", $e->getMessage())[0];
+        $message = explode("\n", $defect->getExceptionAsString());
+        $message = implode('%0A', $message);
 
         $type = $this->getCurrentType();
         $file = "file={$this->relativePath($path)}";


### PR DESCRIPTION
Replaces `\n` with `%0A` to display multiline messages in annotations.

Learned from: https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448

![Example](https://i.imgur.com/nnSCPTG.png)