### PR TITLE
Add PHPUnit 7 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         php-versions: ["7.3", "7.4"]
-        phpunit-version: ["8", "9"]
+        phpunit-version: ["7", "8", "9"]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.os }} (PHPUnit ${{ matrix.phpunit-version }})
     steps:
       - name: Checkout

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -7,6 +7,15 @@ namespace mheap\GithubActionsReporter;
 use PHPUnit\Runner\Version;
 use PHPUnit_TextUI_ResultPrinter;
 
+$low  = version_compare(Version::series(), '7.0', '>=');
+$high = version_compare(Version::series(), '7.99.99', '<=');
+
+if ($low && $high) {
+    class Printer extends Printer7
+    {
+    }
+}
+
 $low  = version_compare(Version::series(), '8.0', '>=');
 $high = version_compare(Version::series(), '8.99.99', '<=');
 

--- a/src/Printer7.php
+++ b/src/Printer7.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace mheap\GithubActionsReporter;
+
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestResult;
+
+class Printer7 extends ResultPrinter
+{
+    protected $currentType = null;
+
+    protected function printHeader(): void
+    {
+    }
+
+    protected function writeProgress(string $progress): void
+    {
+    }
+
+    protected function printFooter(TestResult $result): void
+    {
+    }
+
+    protected function printDefects(array $defects, string $type): void
+    {
+        $this->currentType = $type;
+
+        foreach ($defects as $i => $defect) {
+            $this->printDefect($defect, $i);
+        }
+    }
+
+    protected function printDefectHeader(TestFailure $defect, int $count): void
+    {
+    }
+
+    protected function printDefectTrace(TestFailure $defect): void
+    {
+        $e = $defect->thrownException();
+
+        $errorLines = array_filter(
+            explode("\n", (string)$e),
+            function ($l) {
+                return $l;
+            }
+        );
+
+        $error = end($errorLines);
+        $lineIndex = strrpos($error, ":");
+        $path = substr($error, 0, $lineIndex);
+        $line = substr($error, $lineIndex + 1);
+
+        list($reflectedPath, $reflectedLine) = $this->getReflectionFromTest(
+            $defect->getTestName()
+        );
+
+        if ($path !== $reflectedPath) {
+            $path = $reflectedPath;
+            $line = $reflectedLine;
+        }
+
+        $message = explode("\n", $defect->getExceptionAsString());
+        $message = implode('%0A', $message);
+
+        // Some messages might contain paths. Let's convert thost to relative paths too
+        $message = $this->relativePath($message);
+
+        $message = preg_replace('/%0A$/', '', $message);
+
+        $type = $this->getCurrentType();
+        $file = "file={$this->relativePath($path)}";
+        $line = "line={$line}";
+        $this->write("::{$type} $file,$line::{$message}\n");
+    }
+
+    protected function getCurrentType()
+    {
+        if (in_array($this->currentType, ['error', 'failure'])) {
+            return 'error';
+        }
+
+        return 'warning';
+    }
+
+    protected function relativePath(string $path)
+    {
+        $relative = str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $path);
+        // Translate \ in to / for Windows
+        $relative = str_replace('\\', '/', $relative);
+        return $relative;
+    }
+
+    protected function getReflectionFromTest(string $name)
+    {
+        list($klass, $method) = explode('::', $name);
+        $c = new \ReflectionClass($klass);
+        $m = $c->getMethod($method);
+
+        return [$m->getFileName(), $m->getStartLine()];
+    }
+}


### PR DESCRIPTION
Version 1.3.0 removed support for PHPUnit 7 when we added a list of explicitly allowed versions. This PR reinstates support

Resolves #19 