### PR TITLE
fix signature of printHeader for 8.0.0 ~ 8.5.6

### DIFF
--- a/src/Printer8.php
+++ b/src/Printer8.php
@@ -17,7 +17,7 @@ class Printer8 extends ResultPrinter
      */
     private $currentType;
 
-    protected function printHeader(TestResult $result): void
+    protected function printHeader(TestResult $result = null): void
     {
     }
 


### PR DESCRIPTION
It seems that printHeader has no arguments in PHPUnit 8.5.6 and below :)

---
https://github.com/sebastianbergmann/phpunit/commit/1685173e181af9fafdc452fc9e83222dd23c4c08
https://github.com/sebastianbergmann/phpunit/blob/8.5.6/src/TextUI/ResultPrinter.php#L163